### PR TITLE
Added 'workflow_id' to CartoDB Export

### DIFF
--- a/app/models/carto_transformer.rb
+++ b/app/models/carto_transformer.rb
@@ -121,6 +121,7 @@ class CartoTransformer
           classification_id:     classification["classification_id"],
           subject_id:            subject_id,
           gorongosa_id:          subject_data["Gorongosa_id"],
+          workflow_id:           classification["workflow_id"],
           classified_at:         classification["created_at"],
           species:               ANNOTATION_SPECIES_CHOICES[annotation_value["choice"]],
           species_count:         ANNOTATION_HOW_MANY[answers["HWMN"]],


### PR DESCRIPTION
* I forgot to add `workflow_id` to the Classifications that we send to CartoDB. Oops! Fixed now.
* Note that the `wildcam_classifications` [DB table](https://shaunanoordin-zooniverse.carto.com/tables/wildcam_classifications) had to be modified for this purpose.

For future use, use this CSV as a 'starter seed' to create a fresh `wildcam_classifications` table, modifying `classification_id` to a large enough value so we'll only export recent (students-only) classifications.
```
species_horns,species_interacting,species_eating,species_standing,species_resting,species_moving,species_young,species_count,subject_id,classification_id,species,gorongosa_id,user_group_ids,user_name,workflow_id,classified_at
false,false,true,true,true,true,false,50+,894374,13374904,Baboon,21484_1000_D23_Season 3_Set 1_EK005248,,wildcam_classification_start_seed_entry,338,2016-06-17 15:38:54+00
```
This may be handy on occasions where, e.g. the CartoDB table size doesn't shrink after a Truncate, or we're moving the from . Note that the species_count is deliberately set up so that CartoDB auto-table-maker will realise that species_count needs to be a string, not a number type. 