### PR TITLE
Fix Create New Assignment's 500 error

### DIFF
--- a/app/operations/assignments/create.rb
+++ b/app/operations/assignments/create.rb
@@ -18,8 +18,7 @@ module Assignments
       classroom = current_user.taught_classrooms.find(classroom_id)
 
       subject_set = panoptes.create_subject_set display_name: uuid, links: {
-        project: base_project_id,
-        subjects: []
+        project: base_project_id
       }
 
       FillSubjectSetWorker.perform_async(subject_set["id"], subject_ids)


### PR DESCRIPTION
## Overview
Fixes a 500 server error that prevents Teachers on WGL from creating new Assignments.

TL;DR: **We cannot create a new Subject Set with `subjects` set to an empty array `[]`. Either set some valid subject IDs, or don't put anything at all.**

## Issue
When attempting to Create new Assignments on lab.wildcamgorongosa.org/teachers/classrooms, clicking on the "Submit" button will cause the application to break.

Looking into the browser console, we see that the call to /assignments in the Education API returns a 500 Internal Server error.

## Analysis
Looking into the logs of the Education API, we see this error:
```
I, [2016-10-12T15:02:40.131201 #51]  INFO -- : Started POST "/assignments/" for 163.1.246.64 at 2016-10-12 15:02:40 +0000
I, [2016-10-12T15:02:40.133719 #51]  INFO -- : Processing by AssignmentsController#create as */*
I, [2016-10-12T15:02:40.133888 #51]  INFO -- :   Parameters: {"data"=>{"attributes"=>{"name"=>"Part 2", "metadata"=>{"classifications_target"=>"10", "description"=>"...", "duedate"=>"", "filters"=>{}, "subjects"=>["681504", "687882", "688612", "695637", "696736", "720588", "722759", "737368", "740631", "740988"]}}, "relationships"=>{"classroom"=>{"data"=>{"id"=>"570", "type"=>"classrooms"}}, "student_users"=>{"data"=>[{"id"=>"1114", "type"=>"student_user"}]}, "subjects"=>{"data"=>[{"id"=>"681504", "type"=>"subjects"}, {"id"=>"687882", "type"=>"subjects"}, {"id"=>"688612", "type"=>"subjects"}, {"id"=>"695637", "type"=>"subjects"}, {"id"=>"696736", "type"=>"subjects"}, {"id"=>"720588", "type"=>"subjects"}, {"id"=>"722759", "type"=>"subjects"}, {"id"=>"737368", "type"=>"subjects"}, {"id"=>"740631", "type"=>"subjects"}, {"id"=>"740988", "type"=>"subjects"}]}}}, "assignment"=>{}}
D, [2016-10-12T15:02:40.178903 #51] DEBUG -- :   User Load (0.9ms)  SELECT  "users".* FROM "users" WHERE "users"."zooniverse_id" = $1 LIMIT 1  [["zooniverse_id", "1459668"]]
D, [2016-10-12T15:02:40.182891 #51] DEBUG -- :   Classroom Load (1.0ms)  SELECT  "classrooms".* FROM "classrooms" INNER JOIN "teacher_users" ON "classrooms"."id" = "teacher_users"."classroom_id" WHERE "teacher_users"."user_id" = $1 AND "classrooms"."id" = $2 LIMIT 1  [["user_id", 27], ["id", 570]]
I, [2016-10-12T15:02:40.300504 #51]  INFO -- : Completed 500 Internal Server Error in 166ms
F, [2016-10-12T15:02:40.303515 #51] FATAL -- :
Panoptes::Client::ServerError ({"errors"=>[{"message"=>"Couldn't find linked subjects for current user"}]}):
 app/operations/assignments/create.rb:20:in `execute'
 lib/operand/with.rb:23:in `run'
 app/controllers/application_controller.rb:36:in `run'
 app/controllers/assignments_controller.rb:8:in `create'
```

This corresponds to...
```
subject_set = panoptes.create_subject_set display_name: uuid, links: {
  project: base_project_id,
  subjects: []
}
```

Note that `subjects` was set to `[]` in PR #32 to improve Creation speed; previously the full array of Subject IDs were use to create a subject set, but now an empty subject set is created then the full list added later.

Turns out that Panoptes doesn't like it when `subjects` is an empty array - either `subjects` must be an array of valid Subject IDs, or not specified whatsoever. 

## Solution
Removed `subjects: []`

## Status
Ready for review.