### PR TITLE
Make dotenv package available on all environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'newrelic_rpm', "~> 4.2"
 gem 'active_interaction', "~> 3.5"
 gem 'faraday-panoptes', "~> 0.3"
 gem 'panoptes-client', "~> 0.3"
+gem 'dotenv-rails', "~> 2.2"
 
 group :development, :test do
   gem 'byebug', "~> 9.0"
@@ -24,7 +25,6 @@ group :development, :test do
   gem 'rspec-rails', "~> 3.6"
   gem 'pry-rails', "~> 0.3"
   gem 'faraday-detailed_logger', "~> 2.1"
-  gem 'dotenv-rails', "~> 2.2"
 end
 
 group :development do


### PR DESCRIPTION
## PR Overview
* Currently, the Education API won't build properly on the Legacy container. (Server? Whale? Thingamabob?)
* Error message on Legacy:
```
ubuntu@...:~$ docker-compose up education
Starting legacy_education_1 ... 
Starting legacy_education_1 ... done
Attaching to legacy_education_1
education_1                   | + cd /app
education_1                   | + '[' -d /rails_conf/ ']'
education_1                   | + mkdir -p tmp/pids/
education_1                   | + rm -f 'tmp/pids/*.pid'
education_1                   | + bin/rake db:migrate
education_1                   | rake aborted!
education_1                   | NameError: uninitialized constant Dotenv
education_1                   | /app/config/initializers/dotenv.rb:1:in `<top (required)>'
education_1                   | /app/config/environment.rb:5:in `<top (required)>'
education_1                   | Tasks: TOP => db:migrate => environment
education_1                   | (See full trace by running task with --trace)
legacy_education_1 exited with code 1
```
* Error is caused by the `dotenv-rails` dependency being ONLY defined in the development environment.
* This PR fixes the error by moving the `dotenv-rails` dependency out of the development-only clause.

### Status
Ready for review. 