### PR TITLE
Configure AMS to keep underscores

### DIFF
--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,1 +1,3 @@
 ActiveModel::Serializer.config.adapter = :json_api
+ActiveModel::Serializer.config.key_transform = :unaltered
+


### PR DESCRIPTION
Upgrading AMS from 0.10.rc4 to 0.10.6 added a new default to dasherize JSON keys, which apparently is in the JSON API spec, but our frontend can't handle that.