### PR TITLE
Remove URL arg from Panoptes::Client.new

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,7 @@ class ApplicationController < ActionController::Base
     raise Unauthorized, "missing bearer token" unless authorization_token
 
     @client = Panoptes::Client.new \
+      env: Rails.env.to_sym,
       auth: {token: authorization_token}
   end
 

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -34,7 +34,6 @@ class AssignmentsController < ApplicationController
 
   def panoptes_application_client
     @panoptes_application_client ||= Panoptes::Client.new \
-      url: Rails.application.secrets["zooniverse_oauth_url"],
       auth: {client_id: Rails.application.secrets["zooniverse_oauth_key"],
              client_secret: Rails.application.secrets["zooniverse_oauth_secret"]}
   end

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -34,6 +34,7 @@ class AssignmentsController < ApplicationController
 
   def panoptes_application_client
     @panoptes_application_client ||= Panoptes::Client.new \
+      env: Rails.env.to_sym,
       auth: {client_id: Rails.application.secrets["zooniverse_oauth_key"],
              client_secret: Rails.application.secrets["zooniverse_oauth_secret"]}
   end

--- a/app/workers/worker_helpers.rb
+++ b/app/workers/worker_helpers.rb
@@ -1,6 +1,7 @@
 module WorkerHelpers
   def client
     @client ||= Panoptes::Client.new \
+      env: Rails.env.to_sym,
       auth: {client_id: Rails.application.secrets["zooniverse_oauth_key"],
              client_secret: Rails.application.secrets["zooniverse_oauth_secret"]}
   end

--- a/app/workers/worker_helpers.rb
+++ b/app/workers/worker_helpers.rb
@@ -1,7 +1,6 @@
 module WorkerHelpers
   def client
     @client ||= Panoptes::Client.new \
-      url: Rails.application.secrets["zooniverse_oauth_url"],
       auth: {client_id: Rails.application.secrets["zooniverse_oauth_key"],
              client_secret: Rails.application.secrets["zooniverse_oauth_secret"]}
   end


### PR DESCRIPTION
The different platform clients got consolidated which removed the URL keyword. It's now determined by the env automatically.