### PR TITLE
Base workflow id is an int, not a bool

### DIFF
--- a/app/operations/projects/create.rb
+++ b/app/operations/projects/create.rb
@@ -3,7 +3,7 @@ module Projects
     hash :attributes do
       integer :id
       string :slug
-      boolean :base_workflow_id, default: nil
+      integer :base_workflow_id, default: nil
     end
 
     def execute


### PR DESCRIPTION
forgot to update the Project create op when I made this change originally.