### PR TITLE
Adds show route for /teachers/classrooms/:id

### DIFF
--- a/app/controllers/teachers/classrooms_controller.rb
+++ b/app/controllers/teachers/classrooms_controller.rb
@@ -4,6 +4,10 @@ module Teachers
       run Classrooms::TeacherIndex
     end
 
+    def show
+      run Classrooms::TeacherShow
+    end
+
     def create
       run Classrooms::TeacherCreate, params.to_h.fetch(:data).fetch(:attributes)
     end

--- a/app/operations/classrooms/teacher_show.rb
+++ b/app/operations/classrooms/teacher_show.rb
@@ -1,0 +1,10 @@
+module Classrooms
+  class TeacherShow < Operation
+    integer :id
+    validates :id, presence: true
+
+    def execute
+      Classroom.active.find(id)
+    end
+  end
+end


### PR DESCRIPTION
Wildcam just grabs all a teacher's classrooms and filters them by id on the front end. For other projects, teachers will likely create many more classrooms, making this method not only unwieldy but problematic due to paging. Just grab the one you need.