### PR TITLE
Raise an exception if the record is not found

### DIFF
--- a/app/operations/classrooms/teacher_show.rb
+++ b/app/operations/classrooms/teacher_show.rb
@@ -4,7 +4,7 @@ module Classrooms
     validates :id, presence: true
 
     def execute
-      Classroom.active.find(id)
+      Classroom.active.find!(id)
     end
   end
 end


### PR DESCRIPTION
...rather than show the query in the error response.