### PR TITLE
Publicize GET programs routes

### DIFF
--- a/app/controllers/programs_controller.rb
+++ b/app/controllers/programs_controller.rb
@@ -1,17 +1,27 @@
 class ProgramsController < ApplicationController
+  skip_before_action :require_login
+
   def show
-    run Programs::Show, params
+    anon_run Programs::Show, params
   end
 
   def index
-    run Programs::Index
+    anon_run Programs::Index
   end
 
   def create
     run Programs::Create, params.fetch(:data)
   end
 
-  def update
-    run Programs::Update, params.fetch(:data).merge(id: params[:id])
+  private
+
+  def anon_run(operation_class, data=params)
+    operation = operation_class.run(data)
+
+    if operation.valid?
+      respond_with operation.result
+    else
+      render json: ErrorSerializer.serialize(operation), status: :unprocessable_entity
+    end
   end
 end

--- a/app/controllers/student_area_controller.rb
+++ b/app/controllers/student_area_controller.rb
@@ -8,5 +8,4 @@ class StudentAreaController < ApplicationController
       render json: ErrorSerializer.serialize(operation), status: :unprocessable_entity
     end
   end
-
 end

--- a/app/operations/classrooms/teacher_create.rb
+++ b/app/operations/classrooms/teacher_create.rb
@@ -7,6 +7,10 @@ module Classrooms
 
     validates :name, presence: true
 
+    relationships do
+      belongs_to :program
+    end
+
     def execute
       Classroom.create!(name: name, school: school, subject: subject, description: description, teachers: [current_user]).tap do |classroom|
         panoptes_group = client.panoptes.post("/user_groups", user_groups: {name: SecureRandom.uuid})["user_groups"][0]

--- a/app/operations/classrooms/teacher_update.rb
+++ b/app/operations/classrooms/teacher_update.rb
@@ -9,6 +9,10 @@ module Classrooms
 
     validates :name, presence: true
 
+    relationships do
+      belongs_to :program
+    end
+
     def execute
       classroom = current_user.taught_classrooms.active.find(id)
       classroom.update!(name: name, school: school, subject: subject, description: description)

--- a/app/operations/programs/index.rb
+++ b/app/operations/programs/index.rb
@@ -1,5 +1,5 @@
 module Programs
-  class Index < Operation
+  class Index < ActiveInteraction::Base
     def execute
       Program.all
     end

--- a/app/operations/programs/show.rb
+++ b/app/operations/programs/show.rb
@@ -1,6 +1,7 @@
 module Programs
-  class Show < Operation
+  class Show < ActiveInteraction::Base
     integer :id
+    validates :id, presence: true
 
     def execute
       Program.find(id)


### PR DESCRIPTION
* `GET /programs` and `GET /program/:id` are now public.
* Classroom create and update ops now list program as a relationship so they'll be properly associated.

Fixes #69 