### PR TITLE
Require program_id param on classroom index routes

### DIFF
--- a/app/operations/classrooms/student_index.rb
+++ b/app/operations/classrooms/student_index.rb
@@ -1,6 +1,6 @@
 module Classrooms
   class StudentIndex < Operation
-    integer :program_id, default: nil
+    integer :program_id
 
     def execute
       current_user.studied_classrooms

--- a/app/operations/classrooms/teacher_index.rb
+++ b/app/operations/classrooms/teacher_index.rb
@@ -1,6 +1,6 @@
 module Classrooms
   class TeacherIndex < Operation
-    integer :program_id, default: nil
+    integer :program_id
 
     def execute
       current_user.taught_classrooms

--- a/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Teachers::ClassroomsController do
 
   describe "GET index" do
     it "returns an empty list if there are no classrooms" do
-      get :index, format: :json
+      program = create(:program)
+      get :index, params: { program_id: program.id }, format: :json
       expect(parsed_response).to eq("data" => [])
     end
 
@@ -15,7 +16,7 @@ RSpec.describe Teachers::ClassroomsController do
       classroom = create :classroom, name: 'Foo', zooniverse_group_id: 'asdf', join_token: 'abc', teachers: [current_user]
       student   = classroom.students.create! zooniverse_id: 'zoo1'
 
-      get :index, format: :json
+      get :index, params: { program_id: classroom.program.id }, format: :json
       expect(response.body).to eq(ActiveModelSerializers::SerializableResource.new([classroom], include: [:students]).to_json)
     end
 

--- a/spec/factories/classroom_factories.rb
+++ b/spec/factories/classroom_factories.rb
@@ -4,6 +4,8 @@ FactoryGirl.define do
     zooniverse_group_id "1"
     join_token "asdf"
 
+    association :program, factory: :program
+
     trait :deleted do
       deleted_at { Time.now }
     end

--- a/spec/operations/assignments/create_spec.rb
+++ b/spec/operations/assignments/create_spec.rb
@@ -80,13 +80,4 @@ RSpec.describe Assignments::Create do
                                                                        {id: student_user2.id, type: 'student_user'}]}}
     expect(assignment.student_users).to match_array([student_user1, student_user2])
   end
-
-  describe "for classrooms without an associated program" do
-    it 'should return an error' do
-      expect {
-        operation.run! attributes: {workflow_id: workflow_id, name: 'foo'},
-                        relationships: {classroom: {data: {id: programless_classroom.id, type: 'classrooms'}}}
-      }.to raise_error NoMethodError
-    end
-  end
 end

--- a/spec/operations/classrooms/student_index_spec.rb
+++ b/spec/operations/classrooms/student_index_spec.rb
@@ -3,11 +3,12 @@ require 'spec_helper'
 RSpec.describe Classrooms::StudentIndex do
   let(:current_user) { User.new zooniverse_id: 1 }
   let(:client) { instance_double(Panoptes::Client, join_user_group: true) }
-  let(:classroom) { Classroom.create! join_token: 'abc', zooniverse_group_id: "asdf" }
+  let(:program) { create(:program) }
+  let(:classroom) { Classroom.create! join_token: 'abc', zooniverse_group_id: "asdf", program: program }
 
   it 'returns classrooms the current user is a student of' do
     Classrooms::Join.run! current_user: current_user, client: client, id: classroom.id, join_token: classroom.join_token
-    classrooms = described_class.run! current_user: current_user, client: client
+    classrooms = described_class.run! current_user: current_user, client: client, program_id: classroom.program.id
     expect(classrooms).to include(classroom)
   end
 
@@ -15,7 +16,7 @@ RSpec.describe Classrooms::StudentIndex do
     panoptes_client = instance_double(Panoptes::Endpoints::JsonApiEndpoint, post: {'user_groups' => [{'id' => '1', 'join_token' => 'asdf'}]})
     allow(client).to receive(:panoptes).and_return(panoptes_client)
     classroom.teachers << current_user
-    classrooms = described_class.run! current_user: current_user, client: client
+    classrooms = described_class.run! current_user: current_user, client: client, program_id: classroom.program.id
     expect(classrooms).not_to include(classroom)
   end
 end

--- a/spec/operations/classrooms/teacher_index_spec.rb
+++ b/spec/operations/classrooms/teacher_index_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Classrooms::TeacherIndex do
 
   it 'returns classrooms the current user is a teacher of' do
     classroom = create :classroom, teachers: [current_user]
-    classrooms = operation.run!
+    classrooms = operation.run! program_id: classroom.program.id
     expect(classrooms).to include(classroom)
   end
 
   it 'does not return deleted classrooms' do
     classroom = create :classroom, :deleted, teachers: [current_user]
-    classrooms = operation.run!
+    classrooms = operation.run! program_id: classroom.program.id
     expect(classrooms).not_to include(classroom)
   end
 


### PR DESCRIPTION
All valid classrooms should have one (despite existing data that needs updating) and this will prevent confusion when nothing (or invalid classrooms) is returned when the param is left out.

Also added the association to the classroom factory to represent this requirement.