### PR TITLE
Default assignments on classroom join

### DIFF
--- a/app/operations/classrooms/join.rb
+++ b/app/operations/classrooms/join.rb
@@ -11,7 +11,7 @@ module Classrooms
 
       if response
         classroom.students << current_user
-        add_user_to_assignments if !classroom.program.custom?
+        add_user_to_assignments unless classroom.program.custom?
       else
         errors.add(:id, "cannot join")
       end

--- a/app/operations/classrooms/join.rb
+++ b/app/operations/classrooms/join.rb
@@ -7,11 +7,11 @@ module Classrooms
     validates :join_token, presence: true
 
     def execute
-      classroom = Classroom.active.find_by!(id: id, join_token: join_token)
       response = join_panoptes_group(classroom)
 
       if response
         classroom.students << current_user
+        add_user_to_assignments if !classroom.program.custom?
       else
         errors.add(:id, "cannot join")
       end
@@ -23,6 +23,20 @@ module Classrooms
       client.join_user_group(classroom.zooniverse_group_id, current_user.zooniverse_id, join_token: classroom.join_token)
     rescue Panoptes::Client::ServerError
       false
+    end
+
+    def add_user_to_assignments
+      classroom.assignments.each do |assignment|
+        assignment.student_users << student_user
+      end
+    end
+
+    def classroom
+      Classroom.active.find_by!(id: id, join_token: join_token)
+    end
+
+    def student_user
+      StudentUser.where(user_id: current_user.id, classroom_id: classroom.id).first
     end
   end
 end

--- a/app/operations/classrooms/teacher_index.rb
+++ b/app/operations/classrooms/teacher_index.rb
@@ -1,6 +1,6 @@
 module Classrooms
   class TeacherIndex < Operation
-    integer :program_id, default: nil
+    integer :program_id
 
     def execute
       current_user.taught_classrooms

--- a/spec/controllers/students/classrooms_controller_spec.rb
+++ b/spec/controllers/students/classrooms_controller_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe Students::ClassroomsController do
   end
 
   describe "POST join" do
+    let(:classroom) { create(:classroom) }
     it "joins a classroom" do
-      expect(user_client).to receive(:join_user_group).with(nil, "9999", join_token: "asdf").and_return(true)
-      classroom = Classroom.create! name: '1', join_token: 'asdf'
-      post :join, params: {id: classroom.id, join_token: 'asdf'}, as: :json
+      expect(user_client).to receive(:join_user_group).with(classroom.zooniverse_group_id, current_user.zooniverse_id, join_token: classroom.join_token).and_return(true)
+      post :join, params: {id: classroom.id, join_token: classroom.join_token}, as: :json
       expect(response.body).to eq(ActiveModelSerializers::SerializableResource.new(classroom, include: [:students]).to_json)
     end
   end

--- a/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -6,16 +6,18 @@ RSpec.describe Teachers::ClassroomsController do
   before { authenticate! }
 
   describe "GET index" do
+    let(:program) {create(:program)}
+
     it "returns an empty list if there are no classrooms" do
-      get :index, format: :json
+      get :index, params: { program_id: program.id }, format: :json
       expect(parsed_response).to eq("data" => [])
     end
 
     it 'returns the classrooms with students' do
-      classroom = create :classroom, name: 'Foo', zooniverse_group_id: 'asdf', join_token: 'abc', teachers: [current_user]
+      classroom = create :classroom, name: 'Foo', zooniverse_group_id: 'asdf', join_token: 'abc', teachers: [current_user], program: program
       student   = classroom.students.create! zooniverse_id: 'zoo1'
 
-      get :index, format: :json
+      get :index, params: { program_id: program.id }, format: :json
       expect(response.body).to eq(ActiveModelSerializers::SerializableResource.new([classroom], include: [:students]).to_json)
     end
 

--- a/spec/factories/classroom_factories.rb
+++ b/spec/factories/classroom_factories.rb
@@ -5,8 +5,6 @@ FactoryGirl.define do
     join_token "asdf"
     program
 
-    association :program, factory: :program
-
     trait :deleted do
       deleted_at { Time.now }
     end

--- a/spec/factories/classroom_factories.rb
+++ b/spec/factories/classroom_factories.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     name "Foo"
     zooniverse_group_id "1"
     join_token "asdf"
+    program
 
     trait :deleted do
       deleted_at { Time.now }

--- a/spec/operations/assignments/create_spec.rb
+++ b/spec/operations/assignments/create_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe Assignments::Create do
   let(:client) { instance_double(Panoptes::Client) }
   let(:operation) { described_class.with(current_user: current_user, client: client) }
 
-  let(:program) { create :program }
-  let(:classroom) { create :classroom, teachers: [current_user], program: program }
+  let(:classroom) { create :classroom, teachers: [current_user] }
 
   let(:custom_program) { create(:program, custom: true) }
   let(:custom_classroom) { create :classroom, teachers: [current_user], program: custom_program }

--- a/spec/operations/assignments/create_spec.rb
+++ b/spec/operations/assignments/create_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Assignments::Create do
   let(:custom_program) { create(:program, custom: true) }
   let(:custom_classroom) { create :classroom, teachers: [current_user], program: custom_program }
 
-  let(:programless_classroom) { create :classroom, teachers: [current_user] }
+  let(:programless_classroom) { create :classroom, teachers: [current_user], program: nil}
 
   let(:workflow_id) { 999 }
 

--- a/spec/operations/classrooms/join_spec.rb
+++ b/spec/operations/classrooms/join_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe Classrooms::Join do
-  let(:current_user) { build :user }
+  let(:current_user) { create(:user) }
   let(:client) { instance_double(Panoptes::Client) }
-  let(:classroom) { create :classroom }
+  let(:classroom) { create(:classroom) }
 
   before { allow(client).to receive(:join_user_group).and_return(true) }
 
@@ -28,5 +28,30 @@ RSpec.describe Classrooms::Join do
       id: classroom.id, join_token: classroom.join_token
     expect(classroom.students).to include(current_user)
     expect(client).not_to have_received(:join_user_group)
+  end
+
+  describe "assignment assignment" do
+    describe "custom programs" do
+      let(:custom_program) { create(:program, custom: true) }
+      let(:custom_classroom) { create(:classroom, program: custom_program) }
+      let!(:custom_assignment) { create(:assignment, classroom: custom_classroom) }
+
+      it "doesn't affect assignments" do
+        expect{
+          outcome = described_class.run!(current_user: current_user, client: client,
+            id: classroom.id, join_token: classroom.join_token)
+        }.to_not change{ custom_assignment.student_users }
+      end
+    end
+
+    describe "standard programs" do
+      let!(:standard_assignment) { create(:assignment, classroom: classroom) }
+
+      it "adds the user to all assignments" do
+        outcome = described_class.run!(current_user: current_user, client: client,
+          id: classroom.id, join_token: classroom.join_token)
+        expect(standard_assignment.student_users.map {|su| su.user_id }).to include(current_user.id)
+      end
+    end
   end
 end

--- a/spec/operations/classrooms/join_spec.rb
+++ b/spec/operations/classrooms/join_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Classrooms::Join do
       it "adds the user to all assignments" do
         outcome = described_class.run!(current_user: current_user, client: client,
           id: classroom.id, join_token: classroom.join_token)
-        expect(standard_assignment.student_users.map {|su| su.user_id }).to include(current_user.id)
+        expect(standard_assignment.student_users.map(&:user_id)).to include(current_user.id)
       end
     end
   end

--- a/spec/operations/classrooms/student_index_spec.rb
+++ b/spec/operations/classrooms/student_index_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 RSpec.describe Classrooms::StudentIndex do
   let(:current_user) { User.new zooniverse_id: 1 }
   let(:client) { instance_double(Panoptes::Client, join_user_group: true) }
-  let(:classroom) { Classroom.create! join_token: 'abc', zooniverse_group_id: "asdf" }
+  let(:classroom) { create(:classroom, join_token: 'abc', zooniverse_group_id: "asdf") }
 
   it 'returns classrooms the current user is a student of' do
     Classrooms::Join.run! current_user: current_user, client: client, id: classroom.id, join_token: classroom.join_token
-    classrooms = described_class.run! current_user: current_user, client: client
+    classrooms = described_class.run! current_user: current_user, client: client, program_id: classroom.program.id
     expect(classrooms).to include(classroom)
   end
 

--- a/spec/operations/classrooms/teacher_index_spec.rb
+++ b/spec/operations/classrooms/teacher_index_spec.rb
@@ -7,22 +7,22 @@ RSpec.describe Classrooms::TeacherIndex do
 
   it 'returns classrooms the current user is a teacher of' do
     classroom = create :classroom, teachers: [current_user]
-    classrooms = operation.run!
+    classrooms = operation.run! program_id: classroom.program.id
     expect(classrooms).to include(classroom)
   end
 
   it 'does not return deleted classrooms' do
     classroom = create :classroom, :deleted, teachers: [current_user]
-    classrooms = operation.run!
+    classrooms = operation.run! program_id: classroom.program.id
     expect(classrooms).not_to include(classroom)
   end
 
   it 'filters by program id' do
-    program = create(:program)
+    new_program = create(:program)
     classroom = create :classroom, teachers: [current_user]
-    program_classroom = create :classroom, teachers: [current_user], program: program
-    result = operation.run! program_id: program.id
-    expect(result).to include(program_classroom)
+    new_program_classroom = create :classroom, teachers: [current_user], program: new_program
+    result = operation.run! program_id: new_program.id
+    expect(result).to include(new_program_classroom)
     expect(result).not_to include(classroom)
   end
 end


### PR DESCRIPTION
For "custom" (Wildcam-style, custom assignment) programs, teachers create assignments before or after a classroom is joined and then assign them to students. However, for non-custom (i2a) programs, the order of operations will look more like this:

1) Teacher creates classroom
2) Default assignments are automatically generated by the i2a frontend.
3) Stutent attempts to join classroom and is automatically assigned each of the classroom's assignments.

This PR adds that check, based on the program's `custom` attribute, and assigns them if it is false. Programs are now required by all classroom requests and are an included association in the classroom factory.