### PR TITLE
Refactor of assignment creation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
-    faraday (0.12.2)
+    faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     faraday-detailed_logger (2.1.1)
       faraday (~> 0.8)
@@ -124,7 +124,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
-    panoptes-client (0.3.2)
+    panoptes-client (0.3.4)
       faraday
       faraday-panoptes (~> 0.3.0)
       jwt (~> 1.5.0)
@@ -265,4 +265,4 @@ DEPENDENCIES
   web-console (~> 3.5)
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -15,8 +15,11 @@ RSpec.describe AssignmentsController do
   end
 
   describe "POST create" do
+    let(:workflow_id) { 8888 }
+
     before do
       allow(controller).to receive(:panoptes_application_client).and_return(application_client)
+      allow(application_client).to receive(:workflow).and_return({"id"=> workflow_id, "links" => {"project" => "1"}})
     end
 
     it 'returns a new assignment' do
@@ -25,7 +28,7 @@ RSpec.describe AssignmentsController do
       assignment = build(:assignment, classroom: classroom)
       outcome = double(result: assignment, valid?: true)
 
-      attributes = {workflow_id: '8888', name: "Foo"}
+      attributes = {workflow_id: workflow_id, name: "Foo"}
       relationships = {classroom: {data: {id: classroom.id, type: 'classrooms'}}}
 
       post :create, params: {data: {attributes: attributes, relationships: relationships}}, format: :json

--- a/spec/operations/assignments/create_spec.rb
+++ b/spec/operations/assignments/create_spec.rb
@@ -13,11 +13,19 @@ RSpec.describe Assignments::Create do
   let(:programless_classroom) { create :classroom, teachers: [current_user], program: nil}
 
   let(:workflow_id) { 999 }
+  let(:cloned_workflow_id) { 123 }
+  let(:cloned_workflow) {
+    {
+     "id" => cloned_workflow_id,
+     "links" => {"project" => "1"}
+    }
+  }
 
   before do
-    allow(client).to receive(:workflow).and_return("links" => {"project" => "1"})
-    allow(client).to receive(:create_workflow).and_return("id" => "999", "links" => {"project" => "1"})
+    allow(client).to receive(:workflow).and_return({"id"=> workflow_id, "links" => {"project" => "1"}})
+    allow(client).to receive(:create_workflow).and_return(cloned_workflow)
     allow(client).to receive(:create_subject_set).and_return("id" => "123")
+    allow(client).to receive(:add_subject_set_to_workflow).and_return("id" => "123")
     allow(client).to receive(:add_subjects_to_subject_set).and_return(true)
   end
 
@@ -32,8 +40,8 @@ RSpec.describe Assignments::Create do
       expect(client).to receive(:create_workflow)
                       .with("display_name" => an_instance_of(String),
                             "retirement" => {criteria: "never_retire", options: {}},
-                            "links" => {project: "1", subject_sets: ["123"]})
-                      .and_return("id" => "2")
+                            "links" => {project: "1"})
+                      .and_return(cloned_workflow)
       operation.run!  attributes: {workflow_id: workflow_id, name: 'foo'},
                       relationships: {classroom: {data: {id: custom_classroom.id, type: 'classrooms'}}}
     end


### PR DESCRIPTION
Assignments weren't being created correctly on custom programs. This was because programs != programs and subject sets need a project. Now, the assignment creation order of operations looks like this:

is the program custom (wildcam-style)?
   * clone the workflow indicated in request
   * create and fill subject set using project id from response from above
   * link that subject set to the cloned workflow
   * create assignment (incl. workflow_id = cloned workflow id and subject_set_id)

not custom? (i2a-alike)
   * get workflow data from panoptes using id in request
   * create assignment (incl. assignment.workflow_id = workflow id )

Required an additional call to panoptes because the project id is needed before the workflow is cloned, but not really an issue. Also required addition of a client method on the Panoptes client to add a subject set to a workflow, so the version is bumped.

I don't think there was ever an issue for this, so cc: @srallen