### PR TITLE
Catches Panoptes API not-founds and treat them like ARs.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   respond_to :json
   rescue_from Unauthorized, with: :not_authorized
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
+  rescue_from Panoptes::Client::ResourceNotFound, with: :not_found
 
   before_action :require_login, except: [:root]
 

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 RSpec.describe AssignmentsController do
   include AuthenticationHelpers
 
-  before { authenticate! }
+  before do
+    authenticate!
+    allow(controller).to receive(:panoptes_application_client).and_return(application_client)
+  end
 
   describe "GET index" do
     it 'returns a list of assignments' do
@@ -16,32 +19,39 @@ RSpec.describe AssignmentsController do
 
   describe "POST create" do
     let(:workflow_id) { 8888 }
+    let(:program) { create(:program) }
+    let(:classroom) { create(:classroom, program: program, teachers: [current_user]) }
+    let(:attributes) { {workflow_id: workflow_id, name: "Foo"} }
+    let(:relationships) { {classroom: {data: {id: classroom.id, type: 'classrooms'}}} }
 
-    before do
-      allow(controller).to receive(:panoptes_application_client).and_return(application_client)
-      allow(application_client).to receive(:workflow).and_return({"id"=> workflow_id, "links" => {"project" => "1"}})
+    describe "with a valid workflow" do
+      before do
+        allow(application_client).to receive(:workflow).and_return({"id"=> workflow_id, "links" => {"project" => "1"}})
+      end
+
+      it 'returns a new assignment' do
+        assignment = build(:assignment, classroom: classroom)
+        outcome = double(result: assignment, valid?: true)
+
+        post :create, params: {data: {attributes: attributes, relationships: relationships}}, format: :json
+        expect(response.status).to eq(201)
+        expect(parsed_response[:data][:attributes][:name]).to eq(assignment.name)
+      end
     end
 
-    it 'returns a new assignment' do
-      program = create(:program)
-      classroom  = create(:classroom, program: program, teachers: [current_user])
-      assignment = build(:assignment, classroom: classroom)
-      outcome = double(result: assignment, valid?: true)
+    describe "with an invalid workflow" do
+      before do
+        allow(application_client).to receive(:workflow).and_raise(Panoptes::Client::ResourceNotFound)
+      end
 
-      attributes = {workflow_id: workflow_id, name: "Foo"}
-      relationships = {classroom: {data: {id: classroom.id, type: 'classrooms'}}}
-
-      post :create, params: {data: {attributes: attributes, relationships: relationships}}, format: :json
-      expect(response.status).to eq(201)
-      expect(parsed_response[:data][:attributes][:name]).to eq(assignment.name)
+      it 'returns not found if workflow is not found on Panoptes' do
+        post :create, params: {data: {attributes: attributes, relationships: relationships}}, format: :json
+        expect(response.status).to eq(404)
+      end
     end
   end
 
   describe "DELETE" do
-    before do
-      allow(controller).to receive(:panoptes_application_client).and_return(application_client)
-    end
-
     it 'marks the assignment as deleted' do
       classroom  = create(:classroom, teachers: [current_user])
       assignment = create(:assignment, id: 123, classroom: classroom)


### PR DESCRIPTION
Don't let `Panoptes::Client::ResourceNotFound` exceptions turn into 500s. This will catch them like ActiveRecord not-founds and return a more sensible 404.