### PR TITLE
Fix classroom creation

### DIFF
--- a/app/operations/assignments/update.rb
+++ b/app/operations/assignments/update.rb
@@ -26,8 +26,7 @@ module Assignments
         if subject_ids
           client.update_subject_set links: {subjects: subject_ids}
         end
-
-        assignment.save!
+        assignment.tap(&:save!)
       end
     end
   end

--- a/app/operations/classrooms/teacher_create.rb
+++ b/app/operations/classrooms/teacher_create.rb
@@ -19,6 +19,7 @@ module Classrooms
       classroom.school = attributes[:school] if attributes[:school]
       classroom.subject = attributes[:subject] if attributes[:subject]
       classroom.description = attributes[:description] if attributes[:description]
+      classroom.save!
       join_group(classroom)
     end
 

--- a/app/operations/classrooms/teacher_update.rb
+++ b/app/operations/classrooms/teacher_update.rb
@@ -15,7 +15,11 @@ module Classrooms
 
     def execute
       classroom = current_user.taught_classrooms.active.find(id)
-      classroom.update!(name: name, school: school, subject: subject, description: description)
+      classroom.name = name if name
+      classroom.school = school if school
+      classroom.subject = subject if subject
+      classroom.description = description if description
+      classroom.save!
       classroom
     end
   end

--- a/spec/operations/classrooms/teacher_create_spec.rb
+++ b/spec/operations/classrooms/teacher_create_spec.rb
@@ -9,8 +9,10 @@ RSpec.describe Classrooms::TeacherCreate do
   it 'creates a classroom' do
     created_user_group = {'id' => 1, 'join_token' => 'asdf'}
     allow(client).to receive_message_chain(:panoptes, :post).with("/user_groups", user_groups: {name: an_instance_of(String)}).and_return("user_groups" => [created_user_group])
-    classroom = operation.run!  attributes: { name: "Kool Klass" },
+    classroom = operation.run!  attributes: { name: "Kool Klass", description: "A Kool, Kool Klass For Kool Kids", school: "Kool Skool" },
                                 relationships: {program: {data: {id: program.id, type: 'program'}}}
+
+    classroom.reload
     expect(classroom.name).to eq("Kool Klass")
     expect(program.classrooms.count).to eq(1)
     expect(classroom.program).to eq(program)

--- a/spec/operations/classrooms/teacher_update_spec.rb
+++ b/spec/operations/classrooms/teacher_update_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Classrooms::TeacherUpdate do
 
   it 'changes a classroom attributes', :aggregate_failures do
     result = operation.run! id: classroom.id, name: 'foobar', school: 'school-updated', subject: 'subject-updated', description: 'description-updated'
+    result.reload
     expect(result.name).to eq('foobar')
     expect(result.school).to eq('school-updated')
     expect(result.subject).to eq('subject-updated')


### PR DESCRIPTION
Attributes were being ignored because the classroom wasn't being saved after updating the object in the operation. This wasn't being caught by the spec because the test object wasn't being reloaded from the db before testing it. Also fixed the update op so that it won't update non-included attributes to nil.

Fixes https://github.com/zooniverse/education-api/issues/83
