### PR TITLE
Count classifications by single user group

### DIFF
--- a/app/operations/kinesis/count_classification.rb
+++ b/app/operations/kinesis/count_classification.rb
@@ -11,7 +11,7 @@ module Kinesis
         array :user_group_ids, default: [] do
           integer
         end
-        string :user_group, default: ""
+        string :selected_user_group_id, default: ""
       end
 
       hash :links do
@@ -35,12 +35,12 @@ module Kinesis
           StudentAssignment.increment_counter :classifications_count, student_assignment_id
         end
 
-        if user_group.blank?
+        if selected_user_group_id.blank?
           Classroom.where(zooniverse_group_id: data[:metadata][:user_group_ids]).pluck(:id).each do |id|
             Classroom.increment_counter :classifications_count, id
           end
         else
-          classroom = Classroom.find_by_zooniverse_group_id(data[:metadata][:user_group])
+          classroom = Classroom.find_by_zooniverse_group_id(data[:metadata][:selected_user_group_id])
           Classroom.increment_counter :classifications_count, classroom.id
         end
       end
@@ -66,8 +66,8 @@ module Kinesis
       data[:metadata][:user_group_ids]
     end
 
-    def user_group
-      data[:metadata][:user_group]
+    def selected_user_group_id
+      data[:metadata][:selected_user_group_id]
     end
   end
 end

--- a/app/operations/kinesis/count_classification.rb
+++ b/app/operations/kinesis/count_classification.rb
@@ -11,6 +11,7 @@ module Kinesis
         array :user_group_ids, default: [] do
           integer
         end
+        string :user_group, default: ""
       end
 
       hash :links do
@@ -34,8 +35,13 @@ module Kinesis
           StudentAssignment.increment_counter :classifications_count, student_assignment_id
         end
 
-        Classroom.where(zooniverse_group_id: data[:metadata][:user_group_ids]).pluck(:id).each do |id|
-          Classroom.increment_counter :classifications_count, id
+        unless user_group.blank?
+          classroom = Classroom.find_by_zooniverse_group_id(data[:metadata][:user_group])
+          Classroom.increment_counter :classifications_count, classroom.id
+        else
+          Classroom.where(zooniverse_group_id: data[:metadata][:user_group_ids]).pluck(:id).each do |id|
+            Classroom.increment_counter :classifications_count, id
+          end
         end
       end
 
@@ -58,6 +64,10 @@ module Kinesis
 
     def user_group_ids
       data[:metadata][:user_group_ids]
+    end
+
+    def user_group
+      data[:metadata][:user_group]
     end
   end
 end

--- a/app/operations/kinesis/count_classification.rb
+++ b/app/operations/kinesis/count_classification.rb
@@ -35,13 +35,13 @@ module Kinesis
           StudentAssignment.increment_counter :classifications_count, student_assignment_id
         end
 
-        unless user_group.blank?
-          classroom = Classroom.find_by_zooniverse_group_id(data[:metadata][:user_group])
-          Classroom.increment_counter :classifications_count, classroom.id
-        else
+        if user_group.blank?
           Classroom.where(zooniverse_group_id: data[:metadata][:user_group_ids]).pluck(:id).each do |id|
             Classroom.increment_counter :classifications_count, id
           end
+        else
+          classroom = Classroom.find_by_zooniverse_group_id(data[:metadata][:user_group])
+          Classroom.increment_counter :classifications_count, classroom.id
         end
       end
 

--- a/spec/fixtures/example_kinesis_payload.json
+++ b/spec/fixtures/example_kinesis_payload.json
@@ -34,6 +34,7 @@
             "live_project": true,
             "user_language": "en",
             "user_group_ids": [1234],
+            "user_group": "1234",
             "subject_dimensions": [
                 {
                     "clientWidth": 800,

--- a/spec/fixtures/example_kinesis_payload.json
+++ b/spec/fixtures/example_kinesis_payload.json
@@ -34,7 +34,7 @@
             "live_project": true,
             "user_language": "en",
             "user_group_ids": [1234],
-            "user_group": "1234",
+            "selected_user_group_id": "1234",
             "subject_dimensions": [
                 {
                     "clientWidth": 800,

--- a/spec/operations/kinesis/count_classification_spec.rb
+++ b/spec/operations/kinesis/count_classification_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Kinesis::CountClassification do
   let(:payload) { JSON.load(File.read(Rails.root.join("spec/fixtures/example_kinesis_payload.json"))) }
   let(:operation) { described_class.with(payload) }
 
-  let(:payload_sans_user_group) { payload.tap { |p| p["data"]["metadata"].delete("user_group") } }
+  let(:payload_sans_user_group) { payload.tap { |p| p["data"]["metadata"].delete("selected_user_group_id") } }
   let(:operation_sans_user_group) { described_class.with(payload_sans_user_group) }
 
   let(:student)   { create :user, zooniverse_id: "1234" }

--- a/spec/operations/kinesis/count_classification_spec.rb
+++ b/spec/operations/kinesis/count_classification_spec.rb
@@ -4,19 +4,39 @@ RSpec.describe Kinesis::CountClassification do
   let(:payload) { JSON.load(File.read(Rails.root.join("spec/fixtures/example_kinesis_payload.json"))) }
   let(:operation) { described_class.with(payload) }
 
+  let(:payload_sans_user_group) { payload.tap { |p| p["data"]["metadata"].delete("user_group") } }
+  let(:operation_sans_user_group) { described_class.with(payload_sans_user_group) }
+
   let(:student)   { create :user, zooniverse_id: "1234" }
   let(:classroom) { create :classroom, zooniverse_group_id: "1234", students: [student] }
 
-  it 'increments counter for the classroom' do
-    expect { operation.run! }.to change { classroom.reload.classifications_count }.from(0).to(1)
+  context "with user group" do
+    it 'increments counter for the classroom' do
+      expect { operation.run! }.to change { classroom.reload.classifications_count }.from(0).to(1)
+    end
+
+    it 'increments counter for a student' do
+      expect { operation.run! }.to change { classroom.student_users.first.reload.classifications_count }.from(0).to(1)
+    end
+
+    it 'increments counter for a student in an assignment' do
+      create :assignment, classroom: classroom, student_users: classroom.student_users, workflow_id: "4378"
+      expect { operation.run! }.to change { classroom.student_users.first.student_assignments.first.reload.classifications_count }.from(0).to(1)
+    end
   end
 
-  it 'increments counter for a student' do
-    expect { operation.run! }.to change { classroom.student_users.first.reload.classifications_count }.from(0).to(1)
-  end
+  context "without user group" do
+    it 'increments counter for the classroom' do
+      expect { operation_sans_user_group.run! }.to change { classroom.reload.classifications_count }.from(0).to(1)
+    end
 
-  it 'increments counter for a student in an assignment' do
-    create :assignment, classroom: classroom, student_users: classroom.student_users, workflow_id: "4378"
-    expect { operation.run! }.to change { classroom.student_users.first.student_assignments.first.reload.classifications_count }.from(0).to(1)
+    it 'increments counter for a student' do
+      expect { operation_sans_user_group.run! }.to change { classroom.student_users.first.reload.classifications_count }.from(0).to(1)
+    end
+
+    it 'increments counter for a student in an assignment' do
+      create :assignment, classroom: classroom, student_users: classroom.student_users, workflow_id: "4378"
+      expect { operation_sans_user_group.run! }.to change { classroom.student_users.first.student_assignments.first.reload.classifications_count }.from(0).to(1)
+    end
   end
 end


### PR DESCRIPTION
Non-custom (i2a-style) projects include a "user group" key in the classification metadata that indicates the specific UG/classroom that should be incremented. 

This PR ensures that in these cases, only the single classroom's counter is incremented rather than the corresponding classroom for every non-ID user group the user is in. 

This latter case seems to be the desired behavior for Wildcam-style projects, so if there is no user group included in the classfication metadata (i.e. there was no query param on the URL during classification) then they'll all be ticked as before.
  
Sorry that the spec diff is a little gross, it's just doubling them into two separate contexts (with UG and w/o).