### PR TITLE
Non-UG assignment counters shouldn't increment

### DIFF
--- a/app/operations/kinesis/count_classification.rb
+++ b/app/operations/kinesis/count_classification.rb
@@ -29,13 +29,14 @@ module Kinesis
           StudentUser.increment_counter :classifications_count, student_user_id
         end
 
-        sas = StudentAssignment
-              .joins(:assignment)
-              .where(assignments: {workflow_id: workflow_id}, student_user_id: student_user_ids).each do |sa|
-          if selected_user_group_id.blank? || sa.assignment.classroom.zooniverse_group_id == selected_user_group_id.to_i
-            StudentAssignment.increment_counter :classifications_count, sa.id
-          end
+        StudentAssignment
+          .joins(:assignment)
+          .where(assignments: {workflow_id: workflow_id}, student_user_id: student_user_ids).each do |student_assignment|
+        if selected_user_group_id.blank? ||
+            student_assignment.assignment.classroom.zooniverse_group_id == selected_user_group_id.to_i
+          StudentAssignment.increment_counter :classifications_count, student_assignment.id
         end
+      end
 
         if selected_user_group_id.blank?
           Classroom.where(zooniverse_group_id: user_group_ids).pluck(:id).each do |id|

--- a/app/operations/kinesis/count_classification.rb
+++ b/app/operations/kinesis/count_classification.rb
@@ -29,18 +29,20 @@ module Kinesis
           StudentUser.increment_counter :classifications_count, student_user_id
         end
 
-        StudentAssignment.joins(:assignment).where(assignments: {workflow_id: workflow_id},
-                                                   student_user_id: student_user_ids)
-                                            .pluck(:id).each do |student_assignment_id|
-          StudentAssignment.increment_counter :classifications_count, student_assignment_id
+        sas = StudentAssignment
+              .joins(:assignment)
+              .where(assignments: {workflow_id: workflow_id}, student_user_id: student_user_ids).each do |sa|
+          if selected_user_group_id.blank? || sa.assignment.classroom.zooniverse_group_id == selected_user_group_id.to_i
+            StudentAssignment.increment_counter :classifications_count, sa.id
+          end
         end
 
         if selected_user_group_id.blank?
-          Classroom.where(zooniverse_group_id: data[:metadata][:user_group_ids]).pluck(:id).each do |id|
+          Classroom.where(zooniverse_group_id: user_group_ids).pluck(:id).each do |id|
             Classroom.increment_counter :classifications_count, id
           end
         else
-          classroom = Classroom.find_by_zooniverse_group_id(data[:metadata][:selected_user_group_id])
+          classroom = Classroom.find_by_zooniverse_group_id(selected_user_group_id)
           Classroom.increment_counter :classifications_count, classroom.id
         end
       end

--- a/app/operations/kinesis/count_classification.rb
+++ b/app/operations/kinesis/count_classification.rb
@@ -32,11 +32,11 @@ module Kinesis
         StudentAssignment
           .joins(:assignment)
           .where(assignments: {workflow_id: workflow_id}, student_user_id: student_user_ids).each do |student_assignment|
-        if selected_user_group_id.blank? ||
+          if selected_user_group_id.blank? ||
             student_assignment.assignment.classroom.zooniverse_group_id == selected_user_group_id.to_i
-          StudentAssignment.increment_counter :classifications_count, student_assignment.id
+            StudentAssignment.increment_counter :classifications_count, student_assignment.id
+          end
         end
-      end
 
         if selected_user_group_id.blank?
           Classroom.where(zooniverse_group_id: user_group_ids).pluck(:id).each do |id|

--- a/spec/operations/kinesis/count_classification_spec.rb
+++ b/spec/operations/kinesis/count_classification_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe Kinesis::CountClassification do
   let(:payload_sans_user_group) { payload.tap { |p| p["data"]["metadata"].delete("selected_user_group_id") } }
   let(:operation_sans_user_group) { described_class.with(payload_sans_user_group) }
 
-  let(:student)   { create :user, zooniverse_id: "1234" }
-  let(:classroom) { create :classroom, zooniverse_group_id: "1234", students: [student] }
+  let!(:student)   { create :user, zooniverse_id: "1234" }
+  let!(:classroom) { create :classroom, zooniverse_group_id: "1234", students: [student] }
+  let!(:non_ug_classroom) { create :classroom, zooniverse_group_id: "9999", students: [student] }
 
   context "with user group" do
     it 'increments counter for the classroom' do
@@ -19,9 +20,18 @@ RSpec.describe Kinesis::CountClassification do
       expect { operation.run! }.to change { classroom.student_users.first.reload.classifications_count }.from(0).to(1)
     end
 
+    it 'only increments the appropriate counter' do
+      expect { operation.run! }.not_to change { non_ug_classroom.reload.classifications_count }
+    end
+
     it 'increments counter for a student in an assignment' do
       create :assignment, classroom: classroom, student_users: classroom.student_users, workflow_id: "4378"
       expect { operation.run! }.to change { classroom.student_users.first.student_assignments.first.reload.classifications_count }.from(0).to(1)
+    end
+
+    it 'only increments the assignment counter for the appropriate classroom' do
+      create :assignment, classroom: non_ug_classroom, student_users: non_ug_classroom.student_users, workflow_id: "4378"
+      expect { operation.run! }.not_to change { non_ug_classroom.student_users.first.student_assignments.first.reload.classifications_count }
     end
   end
 


### PR DESCRIPTION
A classification comes in over the kinesis stream. If the `selected_user_group_id` param is blank, increment all the assignment counters as expected (Wildcam). However, if that param exists, only update the StudentAssignment counter if that assignment's classroom's zooniverse group ID matches. This was already fixed for classrooms.