### PR TITLE
restrict access to sidekiq using basic authentication

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ education:
     - "POSTGRES_HOSTNAME=pg"
     - "POSTGRES_USERNAME=education"
     - "POSTGRES_PASSWORD=education"
+    - "SIDEKIQ_USERNAME=education"
+    - "SIDEKIQ_PASSWORD=education"
   links:
     - postgres:pg
     - redis:redis


### PR DESCRIPTION
and Protect against timing attacks:
See https://codahale.com/a-lesson-in-timing-attacks/
See https://thisdata.com/blog/timing-attacks-against-string-comparison/
Use & (do not use &&) so that it doesn't short circuit.
Use digests to stop length information leaking (see also ActiveSupport::SecurityUtils.variable_size_secure_compare)

# TODO:
- [x] This will require secret updates for the deployed stacks