### PR TITLE
set the serialize_with_project attribute to false

### DIFF
--- a/app/operations/assignments/create.rb
+++ b/app/operations/assignments/create.rb
@@ -35,6 +35,7 @@ module Assignments
 
       attributes = base_workflow.slice('primary_language', 'tasks', 'first_task', 'configuration')
       attributes['display_name'] = uuid
+      attributes['serialize_with_project'] = false
       attributes['retirement'] = {criteria: 'never_retire', options: {}}
       attributes['links'] = {
         project: base_workflow['links']['project']

--- a/spec/operations/assignments/create_spec.rb
+++ b/spec/operations/assignments/create_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Assignments::Create do
       expect(client).to receive(:create_workflow)
                       .with("display_name" => an_instance_of(String),
                             "retirement" => {criteria: "never_retire", options: {}},
+                            "serialize_with_project" => false,
                             "links" => {project: "1"})
                       .and_return(cloned_workflow)
       operation.run!  attributes: {workflow_id: workflow_id, name: 'foo'},


### PR DESCRIPTION
ensure education API cloned workflows do not pollute the linked project serialized responses, these are special workflows that are only accessed directly by ID