### PR TITLE
Get New Relic working again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'sinatra', "~> 2.0", require: nil
 gem 'active_model_serializers', "~> 0.10"
 gem 'puma', "~> 3.12"
 gem 'sdoc', "~> 1.0"
-gem 'newrelic_rpm', "~> 4.2"
+gem 'newrelic_rpm'
 gem 'active_interaction', "~> 3.6"
 gem 'faraday-panoptes', "~> 0.3"
 gem 'panoptes-client', "~> 0.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,7 +258,7 @@ DEPENDENCIES
   gelf
   honeybadger (~> 3.1)
   logstasher
-  newrelic_rpm (~> 4.2)
+  newrelic_rpm
   panoptes-client (~> 0.3)
   pg (~> 0.20)
   pry-byebug (~> 3.6)
@@ -275,4 +275,4 @@ DEPENDENCIES
   web-console (~> 3.7)
 
 BUNDLED WITH
-   1.15.4
+   1.17.3

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -33,11 +33,6 @@ workers 2
 #
 on_worker_boot do
   ActiveRecord::Base.establish_connection
-
-  # Enable New Relic RPM
-  # https://github.com/puma/puma/issues/128#issuecomment-21050609
-  require 'newrelic_rpm'
-  NewRelic::Agent.manual_start
 end
 
 before_fork do

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -8,10 +8,6 @@ port = rails_env == dev_env ? 3000 : 80
 environment rails_env
 state_path "#{app_path}/tmp/pids/puma.state"
 
-if rails_env == "production"
-  stdout_redirect "#{app_path}/log/production.log", "#{app_path}/log/production_err.log", true
-end
-
 if rails_env == 'development'
   worker_timeout 3600
 end


### PR DESCRIPTION
Update the gem. Remove Puma workaround from 2013.

Also, stop explicitly sending logs to files and let stdout get read by kubernetes.