### PR TITLE
Remove sinatra gem and upgrade ruby to 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-slim-stretch
+FROM ruby:2.7-slim
 
 WORKDIR /app
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'honeybadger', "~> 4.12"
 gem 'sidekiq', "~> 5.2"
 gem 'sidetiq', "~> 0.7"
 
-gem 'sinatra', "~> 2.2", require: nil
 gem 'active_model_serializers', "~> 0.10"
 gem 'puma', "~> 5.6"
 gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,8 +124,6 @@ GEM
     mini_portile2 (2.8.0)
     minitest (5.16.2)
     multipart-post (2.1.1)
-    mustermann (1.1.1)
-      ruby2_keywords (~> 0.0.1)
     newrelic_rpm (4.7.1.340)
     nio4r (2.5.8)
     nokogiri (1.13.9)
@@ -202,7 +200,6 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    ruby2_keywords (0.0.5)
     sidekiq (5.2.10)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
@@ -212,11 +209,6 @@ GEM
       celluloid (>= 0.17.3)
       ice_cube (~> 0.14.0)
       sidekiq (>= 4.1.0)
-    sinatra (2.2.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.0)
-      tilt (~> 2.0)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -226,7 +218,6 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.2.1)
     thread_safe (0.3.6)
-    tilt (2.0.10)
     timers (4.1.2)
       hitimes
     tzinfo (1.2.10)
@@ -268,8 +259,7 @@ DEPENDENCIES
   rspec-rails (~> 3.6)
   sidekiq (~> 5.2)
   sidetiq (~> 0.7)
-  sinatra (~> 2.2)
   web-console (~> 3.7)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
ruby 2.6 is EOL so we can safely bump to 2.7 https://www.ruby-lang.org/en/downloads/branches/

also we don't need sinatra to mount the sidekiq UI as we have rails...i'm not sure why it was added in https://github.com/zooniverse/education-api/commit/fd7447fc7ceb2881291886418d1e54b34e442271 so we can safely remove it from use in this repo