### PR TITLE
Add new Galaxy Zoo project to lambda forwarder

### DIFF
--- a/kinesis-to-http/function.py
+++ b/kinesis-to-http/function.py
@@ -4,7 +4,7 @@ import requests
 
 ENDPOINT = "https://education-api.zooniverse.org/kinesis"
 HEADERS  = {"content-type": "application/json"}
-PROJECTS = ["593", "3525", "2308", "2545", "9908", "2789"]
+PROJECTS = ["593", "3525", "2308", "2545", "9908", "2789", "20344"]
 
 def lambda_handler(event, context):
   payloads = [json.loads(base64.b64decode(record["kinesis"]["data"])) for record in event["Records"]]

--- a/kinesis-to-http/lambda.json
+++ b/kinesis-to-http/lambda.json
@@ -2,6 +2,7 @@
   "name": "kinesis-to-http",
   "description": "It forwards ZooStream to Education API HTTP endpoints",
   "region": "us-east-1",
+  "runtime": "python3.9",
   "handler": "function.lambda_handler",
   "role": "arn:aws:iam::927935712646:role/zooniverse-kinesis-lambda",
   "requirements": [],

--- a/kinesis-to-http/requirements.txt
+++ b/kinesis-to-http/requirements.txt
@@ -1,2 +1,2 @@
-lambda-uploader==1.0.1
-requests==2.20.0
+lambda-uploader==1.3.0
+requests==2.28.2


### PR DESCRIPTION
Adds the project id of the new cloned Galaxy Zoo classrooms project to the list that the lambda will forward to EduAPI. 

Needs to be uploaded via `lambda-uploader`, deploying this PR will not do it.