### PR TITLE
Update classroom creation so that associated panoptes user_group's display_name matches classroom.name

### DIFF
--- a/app/operations/classrooms/teacher_create.rb
+++ b/app/operations/classrooms/teacher_create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Classrooms
   class TeacherCreate < Operation
     hash :attributes do
@@ -28,9 +30,11 @@ module Classrooms
     end
 
     def join_group(classroom)
-      panoptes_group = client.panoptes.post("/user_groups", user_groups: {name: SecureRandom.uuid})["user_groups"][0]
-      classroom.update_columns zooniverse_group_id: panoptes_group.fetch("id"),
-                               join_token: panoptes_group.fetch("join_token")
+      panoptes_group = client.panoptes.post('/user_groups',
+                                            user_groups: { name: SecureRandom.uuid,
+                                                           display_name: classroom.name })['user_groups'][0]
+      classroom.update_columns zooniverse_group_id: panoptes_group.fetch('id'),
+                               join_token: panoptes_group.fetch('join_token')
       classroom
     end
   end

--- a/spec/controllers/teachers/classrooms_controller_spec.rb
+++ b/spec/controllers/teachers/classrooms_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Teachers::ClassroomsController do
@@ -5,41 +7,46 @@ RSpec.describe Teachers::ClassroomsController do
 
   before { authenticate! }
 
-  describe "GET index" do
-    let(:program) {create(:program)}
+  describe 'GET index' do
+    let(:program) { create(:program) }
 
-    it "returns an empty list if there are no classrooms" do
+    it 'returns an empty list if there are no classrooms' do
       get :index, params: { program_id: program.id }, format: :json
-      expect(parsed_response).to eq("data" => [])
+      expect(parsed_response).to eq('data' => [])
     end
 
     it 'returns the classrooms with students' do
-      classroom = create :classroom, name: 'Foo', zooniverse_group_id: 'asdf', join_token: 'abc', teachers: [current_user], program: program
-      student   = classroom.students.create! zooniverse_id: 'zoo1'
+      classroom = create :classroom, name: 'Foo', zooniverse_group_id: 'asdf', join_token: 'abc',
+                                     teachers: [current_user], program: program
+      classroom.students.create! zooniverse_id: 'zoo1'
 
       get :index, params: { program_id: classroom.program.id }, format: :json
-      expect(response.body).to eq(ActiveModelSerializers::SerializableResource.new([classroom], include: [:students]).to_json)
+      expect(response.body).to eq(ActiveModelSerializers::SerializableResource.new([classroom],
+                                                                                   include: [:students]).to_json)
     end
 
     it 'filters by program id' do
       program = create(:program)
-      classroom = create :classroom, teachers: [current_user], program: program
+      create :classroom, teachers: [current_user], program: program
       other_classroom = create :classroom
       get :index, params: { program_id: program.id }, format: :json
       expect(parsed_response).not_to include(other_classroom)
     end
   end
 
-  describe "POST create" do
-    let(:program) {create(:program)}
-    it "creates a new classroom" do
-      created_user_group = {'id' => 1, 'join_token' => 'asdf'}
-      allow(user_client).to receive_message_chain(:panoptes, :post).with("/user_groups", user_groups: {name: an_instance_of(String)}).and_return("user_groups" => [created_user_group])
-      relationships = {program: {data: {id: program.id, type: 'program'}}}
-      post :create, params: {data: {attributes: {name: "Foo"}, relationships: relationships}}, format: :json
+  describe 'POST create' do
+    let(:program) { create(:program) }
+    it 'creates a new classroom' do
+      created_user_group = { 'id' => 1, 'join_token' => 'asdf' }
+      allow(user_client).to receive_message_chain(:panoptes, :post).with('/user_groups',
+                                                                         user_groups: { name: an_instance_of(String),
+                                                                                        display_name: 'Foo' }).and_return('user_groups' => [created_user_group])
+      relationships = { program: { data: { id: program.id, type: 'program' } } }
+      post :create, params: { data: { attributes: { name: 'Foo' }, relationships: relationships } }, format: :json
 
       classroom = Classroom.first
-      expect(response.body).to eq(ActiveModelSerializers::SerializableResource.new(classroom, include: [:students]).to_json)
+      expect(response.body).to eq(ActiveModelSerializers::SerializableResource.new(classroom,
+                                                                                   include: [:students]).to_json)
     end
   end
 
@@ -49,7 +56,7 @@ RSpec.describe Teachers::ClassroomsController do
 
     it 'calls the operation' do
       expect(Classrooms::TeacherUpdate).to receive(:run).once.and_return(outcome)
-      put :update, params: {id: classroom.id, data: {attributes: {name: "Foobar"}}}, format: :json
+      put :update, params: { id: classroom.id, data: { attributes: { name: 'Foobar' } } }, format: :json
     end
   end
 end

--- a/spec/operations/classrooms/teacher_create_spec.rb
+++ b/spec/operations/classrooms/teacher_create_spec.rb
@@ -1,19 +1,23 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Classrooms::TeacherCreate do
   let(:current_user) { User.create! zooniverse_id: 1 }
   let(:client) { instance_double(Panoptes::Client) }
   let(:operation) { described_class.with(current_user: current_user, client: client) }
-  let(:program) {create(:program)}
+  let(:program) { create(:program) }
 
   it 'creates a classroom' do
-    created_user_group = {'id' => 1, 'join_token' => 'asdf'}
-    allow(client).to receive_message_chain(:panoptes, :post).with("/user_groups", user_groups: {name: an_instance_of(String)}).and_return("user_groups" => [created_user_group])
-    classroom = operation.run!  attributes: { name: "Kool Klass", description: "A Kool, Kool Klass For Kool Kids", school: "Kool Skool" },
-                                relationships: {program: {data: {id: program.id, type: 'program'}}}
+    created_user_group = { 'id' => 1, 'join_token' => 'asdf' }
+    allow(client).to receive_message_chain(:panoptes, :post).with('/user_groups',
+                                                                  user_groups: { name: an_instance_of(String),
+                                                                                 display_name: 'Kool Klass' }).and_return('user_groups' => [created_user_group])
+    classroom = operation.run!  attributes: { name: 'Kool Klass', description: 'A Kool, Kool Klass For Kool Kids', school: 'Kool Skool' },
+                                relationships: { program: { data: { id: program.id, type: 'program' } } }
 
     classroom.reload
-    expect(classroom.name).to eq("Kool Klass")
+    expect(classroom.name).to eq('Kool Klass')
     expect(program.classrooms.count).to eq(1)
     expect(classroom.program).to eq(program)
   end


### PR DESCRIPTION
Update classroom creation so that associated panoptes user_group's display_name matches classroom.name

Part of https://www.figma.com/file/qbqbmR3t5XV6eKcpuRj7mG/Group-Stats?type=design&node-id=0-1&mode=design design efforts:

Want: Classroom name to be the associated Panoptes `User_group`'s `display_name`. 

Reason why this was not a want before: 
-  `user_group`s were almost treated like "second-class citizen tables" and with new stats features coming up we are treating them like "first-class" 

 